### PR TITLE
Add page on how to use XLSX templates

### DIFF
--- a/docs/bulk-import.rst
+++ b/docs/bulk-import.rst
@@ -1,6 +1,6 @@
-################
+###################
 Bulk data import
-################
+###################
 
 IATI Publisher allows you to import and export activity data in three file formats (XML, CSV and XLSX). This functionality can be useful if you want to import multiple activities, transactions, budgets or results in one go.
 
@@ -15,7 +15,7 @@ While it is possible to add new activities by bulk import, we normally recommend
    IATI Publisher will overwrite your data in the interface if you upload data for an existing activity. Activity identifiers are checked during import to assess whether you are importing a new activity, or updating an existing one. Be careful to avoid losing data when overwriting existing activities.
 
 1) Export your existing data
-============================
+================================
 As IATI Publisher's import functionality requires complete activities to be uploaded, if you are updating an existing activity, you will need to export the data you have entered for it in the interface first. 
 
 1. On the activity listing page, select the activity (or activities) that you want to edit or add data to. 
@@ -39,14 +39,14 @@ If you choose XLSX files, IATI Publisher will show a progress bar as your data f
 This will download a zipped (compressed) folder containing IATI Publisher's four XLSX templates.
 
 2) Add or edit your data
-===========
+==========================
 Once you have exported your activity data, you can edit or add to the exported file as needed, then re-import it to update your activity. Avoid changing the template structure in any way - e.g. by deleting columns or renaming sheets.
 
 See `How do I upload transactions in bulk? <https://docs.publisher.iatistandard.org/en/latest/import-transactions/>`_ as an example.
 
 
 3) Re-import your data file
-========================
+============================
 
 You can access the data import pages from 'Add or Import Activity' in IATI Publisher's header. Select the file format from the dropdown menu that you wish to use:
 
@@ -58,7 +58,7 @@ You can access the data import pages from 'Add or Import Activity' in IATI Publi
 See `Which import template should I use? <https://docs.publisher.iatistandard.org/en/latest/which-template/>`_ for help choosing the right template. 
 
 4) Pre-import checks
-=================
+======================
 Once you have uploaded your data, IATI Publisher will list the activities ready for import with information on any data validation errors. These errors are from the `IATI Validator <https://validator.iatistandard.org/>`_.
 
 Critical errors prevent the activity from being imported, whereas other errors will not prevent import. It is usually easier to fix errors in your data file before importing, rather than after in the interface.

--- a/docs/bulk-import.rst
+++ b/docs/bulk-import.rst
@@ -14,7 +14,7 @@ While it is possible to add new activities by bulk import, we normally recommend
 
    IATI Publisher will overwrite your data in the interface if you upload data for an existing activity. Activity identifiers are checked during import to assess whether you are importing a new activity, or updating an existing one. Be careful to avoid losing data when overwriting existing activities.
 
-Exporting your existing data
+1) Export your existing data
 ============================
 As IATI Publisher's import functionality requires complete activities to be uploaded, if you are updating an existing activity, you will need to export the data you have entered for it in the interface first. 
 
@@ -38,14 +38,14 @@ If you choose XLSX files, IATI Publisher will show a progress bar as your data f
 
 This will download a zipped (compressed) folder containing IATI Publisher's four XLSX templates.
 
-Adding data
+2) Add or edit your data
 ===========
 Once you have exported your activity data, you can edit or add to the exported file as needed, then re-import it to update your activity. Avoid changing the template structure in any way - e.g. by deleting columns or renaming sheets.
 
 See `How do I upload transactions in bulk? <https://docs.publisher.iatistandard.org/en/latest/import-transactions/>`_ as an example.
 
 
-Importing your data file
+3) Re-import your data file
 ========================
 
 You can access the data import pages from 'Add or Import Activity' in IATI Publisher's header. Select the file format from the dropdown menu that you wish to use:
@@ -57,28 +57,7 @@ You can access the data import pages from 'Add or Import Activity' in IATI Publi
 
 See `Which import template should I use? <https://docs.publisher.iatistandard.org/en/latest/which-template/>`_ for help choosing the right template. 
 
-Import via XML
-""""""""""""""
-XML is the file format used by the IATI Standard. IATI Publisher creates and stores IATI XML files for you when you publish your activity and organisation data from the interface. The XML import functionality may be useful if you are transferring IATI activity data from a different publishing tool to IATI Publisher.
-
-
-Import via CSV
-""""""""""""""
-You can download the IATI Publisher CSV template from the `CSV/XML data import page <https://publisher.iatistandard.org/import>`_. This template contains a wide range of IATI Standard fields and it is not necessary to populate everything. Refer to `IATI Standard guidance <https://iatistandard.org/en/iati-standard/203/activity-standard>`_ on how to interpret the fields. 
-
-.. note:: 
-   It is not possible to upload results, indicators or periods for your activities via the CSV import. Use the XLSX import functionality instead.
-
-
-Import via XLSX
-"""""""""""""""
-There are four templates available on the `XLSX import page <https://publisher.iatistandard.org/import/xls>`_. These cover basic activity data, results, indicators and periods.
-
-If you are not publishing results data, you only need to use the 'Basic Activity Data' template. 
-
-See `How do I complete the XLSX templates? <https://docs.publisher.iatistandard.org/en/latest/how-to-xlsx/>`_ for more guidance.
-
-Pre-import checks
+4) Pre-import checks
 =================
 Once you have uploaded your data, IATI Publisher will list the activities ready for import with information on any data validation errors. These errors are from the `IATI Validator <https://validator.iatistandard.org/>`_.
 

--- a/docs/bulk-import.rst
+++ b/docs/bulk-import.rst
@@ -55,6 +55,8 @@ You can access the data import pages from 'Add or Import Activity' in IATI Publi
     :align: center
     :alt: A screenshot of the dropdown header menu, which allows the user to select whether they want to add activity data manually, via XML/CSV, or via XLSX file.
 
+See `Which import template should I use? <https://docs.publisher.iatistandard.org/en/latest/which-template/>`_ for help choosing the right template. 
+
 Import via XML
 """"""""""""""
 XML is the file format used by the IATI Standard. IATI Publisher creates and stores IATI XML files for you when you publish your activity and organisation data from the interface. The XML import functionality may be useful if you are transferring IATI activity data from a different publishing tool to IATI Publisher.
@@ -72,8 +74,9 @@ Import via XLSX
 """""""""""""""
 There are four templates available on the `XLSX import page <https://publisher.iatistandard.org/import/xls>`_. These cover basic activity data, results, indicators and periods.
 
-See `Which import template should I use? <https://docs.publisher.iatistandard.org/en/latest/which-template/>`_ for help choosing the right template. If you are not publishing results data, you only need to use the 'Basic Activity Data' template. 
+If you are not publishing results data, you only need to use the 'Basic Activity Data' template. 
 
+See `How do I complete the XLSX templates? <https://docs.publisher.iatistandard.org/en/latest/how-to-xlsx/>`_ for more guidance.
 
 Pre-import checks
 =================
@@ -91,8 +94,9 @@ You will have the chance to confirm the activities that you want to add or overw
 .. toctree::
    :hidden:
    :titlesonly:
-   :maxdepth: 3
+   :maxdepth: 4
 
    which-template
+   how-to-xlsx
    import-transactions
    results-import

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -16,11 +16,14 @@ The XLSX templates are split into sheets, which correspond to different data ele
 
 Column colour-coding
 """""""""""""""""""""
-Columns in the XLSX templates are colour-coded based on the number of row entries expected. 
-
-Note - this only applies if you choose to populate the sheet. `Core elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ are mandatory, whereas other sheets in the template are optional.
+Columns in the XLSX templates are colour-coded based on the number of row entries expected. Note that this only applies if you choose to populate the sheet. `Core elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ are mandatory, whereas other sheets in the template are optional.
 
 - Pink - column expects a single entry
 - Green - column expects at least one entry, and multiple entries are allowed (e.g. for title narratives in multiple languages)
 - Orange - column is optional and expects a single entry if you choose to complete it
 - Blue - column is optional and can have multiple entries if you choose to complete it
+
+Importing transactions and results
+"""""""""""""""""""""
+`How do I import transactions in bulk? <https://docs.publisher.iatistandard.org/en/latest/import-transactions/>`_
+`How do I import results data? <https://docs.publisher.iatistandard.org/en/latest/results-import/>`_

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -6,15 +6,6 @@ If you are using IATI Publisher's XLSX templates, we recommend `exporting your e
 
 The XLSX templates are split into sheets, which correspond to different data elements of the IATI Standard.
 
-Column colour-coding
-"""""""""""""""""""""
-Columns are colour-coded pink, green, orange or blue based on the number of row entries expected.
-
-- Pink - column expects a single entry
-- Green - column expects at least one entry, and multiple entries are allowed (e.g. for title narratives in multiple languages)
-- Orange - column is optional and expects a single entry if you choose to complete it
-- Blue - column is optional and can have multiple entries if you choose to complete it
-
 .. admonition:: Tips
 
    - Not all sheets need populating - focus on completing `core data elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ first.
@@ -22,3 +13,12 @@ Columns are colour-coded pink, green, orange or blue based on the number of row 
    - If you are entering multiple values (e.g. transactions), enter these over multiple rows in the relevant sheet.
    - Don't edit sheet or column names, or change the order of columns in a sheet.
    - Don't make any edits to the 'Options' sheet.
+
+Column colour-coding
+"""""""""""""""""""""
+Columns in the XLSX templates are colour-coded pink, green, orange or blue based on the number of row entries expected.
+
+- Pink - column expects a single entry
+- Green - column expects at least one entry, and multiple entries are allowed (e.g. for title narratives in multiple languages)
+- Orange - column is optional and expects a single entry if you choose to complete it
+- Blue - column is optional and can have multiple entries if you choose to complete it

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -1,32 +1,25 @@
 ###################################
-Which import template should I use?
+How do I complete the XLSX templates?
 ###################################
 
-IATI Publisher has activity import templates in CSV and XLSX file format. If you are uploading results data (i.e. results, indicators and periods for existing activities), you will need to use the XLSX import. If you are uploading basic activity data, which can include budgets and transactions, you can choose between the CSV and XLSX imports.
+If you are using IATI Publisher's XLSX templates, we recommend `exporting your existing data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_  first, then editing it and re-importing the template.
 
-CSV template
-------------
-IATI Publisher has a single CSV import template, which covers all elements of the IATI Standard for activities apart from `results <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/>`_.
+The XLSX templates are split into sheets, which correspond to different data elements of the IATI Standard.
 
-This template is recommended if you:
+Tips for using the XLSX templates
+---------------------------------
+- Not all sheets need populating - focus on completing core data elements first.
+- The 'Settings' sheet is only needed if you want to override your default values saved in IATI Publisher (i.e. for individual activities that you are importing).
+- If you are entering multiple values (e.g. transactions), enter these over multiple rows in the relevant sheet.
+- Don't edit sheet or column names, or change the order of columns in a sheet.
+- Don't make any edits to the 'Options' sheet.
 
-- want to work in a single flat file, rather than a workbook with multiple sheets
-- don't need embedded codelists or dropdown menus to enter your data
+Colour-coding
+-------------
+Columns are colour-coded pink, green, orange or blue based on the number of row entries expected.
 
+- Pink - column expects a single entry
+- Green - column expects at least one entry, and multiple entries are allowed (e.g. for title narratives in multiple languages)
+- Orange - column is optional and expects a single entry if you choose to complete it
+- Blue - column is optional and can have multiple entries if you choose to complete it
 
-XLSX templates
----------------
-There are four templates available on the `XLSX import page <https://publisher.iatistandard.org/import/xls>`_:
-
-1. Basic Activity Data - covers core and optional IATI data elements for activities, including transactions
-2. Results - to import `results <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/>`_ for existing activities
-3. Indicators - to import `indicators <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/indicator/>`_ for existing results
-4. Periods - to import `periods <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/indicator/period/>`_ for existing indicators
-
-These templates are recommended if you:
-
-- prefer to work in a workbook that has multiple sheets (typically one per element of the IATI Standard)
-- find embedded codelists and dropdown menus helpful for entering your data
-- need help distinguishing between elements of the IATI Standard that require a single entry (e.g. activity status), versus those that accept multiple entries (e.g. budget)
-
-Only one template can be uploaded at a time. It is normally recommended to `export existing activity data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_ before adding to it via the import functionality.

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -2,20 +2,20 @@
 How do I complete the XLSX templates?
 ###################################
 
-If you are using IATI Publisher's XLSX templates, we recommend `exporting your existing data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_  first, then editing it and re-importing the template.
+If you are using IATI Publisher's XLSX templates, we recommend `exporting your existing data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_ first, then editing it and re-importing the template.
 
 The XLSX templates are split into sheets, which correspond to different data elements of the IATI Standard.
 
 Tips for using the XLSX templates
 ---------------------------------
-- Not all sheets need populating - focus on completing core data elements first.
+- Not all sheets need populating - focus on completing `core data elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ first.
 - The 'Settings' sheet is only needed if you want to override your default values saved in IATI Publisher (i.e. for individual activities that you are importing).
 - If you are entering multiple values (e.g. transactions), enter these over multiple rows in the relevant sheet.
 - Don't edit sheet or column names, or change the order of columns in a sheet.
 - Don't make any edits to the 'Options' sheet.
 
-Colour-coding
--------------
+Column colour-coding
+"""""""""""""""""""""
 Columns are colour-coded pink, green, orange or blue based on the number of row entries expected.
 
 - Pink - column expects a single entry

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -26,4 +26,5 @@ Columns in the XLSX templates are colour-coded based on the number of row entrie
 Importing transactions and results
 """""""""""""""""""""
 `How do I import transactions in bulk? <https://docs.publisher.iatistandard.org/en/latest/import-transactions/>`_
+
 `How do I import results data? <https://docs.publisher.iatistandard.org/en/latest/results-import/>`_

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -1,6 +1,6 @@
-###################################
+#########################################
 How do I complete the XLSX templates?
-###################################
+#########################################
 
 If you are using IATI Publisher's XLSX templates, we recommend `exporting your existing data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_ first, then editing it and re-importing the template.
 
@@ -24,7 +24,7 @@ Columns in the XLSX templates are colour-coded based on the number of row entrie
 - Blue - column is optional and can have multiple entries if you choose to complete it
 
 Importing transactions and results
-"""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""
 `How do I import transactions in bulk? <https://docs.publisher.iatistandard.org/en/latest/import-transactions/>`_
 
 `How do I import results data? <https://docs.publisher.iatistandard.org/en/latest/results-import/>`_

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -16,6 +16,7 @@ Columns are colour-coded pink, green, orange or blue based on the number of row 
 - Blue - column is optional and can have multiple entries if you choose to complete it
 
 .. admonition:: Tips
+
    - Not all sheets need populating - focus on completing `core data elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ first.
    - The 'Settings' sheet is only needed if you want to override your default values saved in IATI Publisher (i.e. for individual activities that you are importing).
    - If you are entering multiple values (e.g. transactions), enter these over multiple rows in the relevant sheet.

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -1,0 +1,32 @@
+###################################
+Which import template should I use?
+###################################
+
+IATI Publisher has activity import templates in CSV and XLSX file format. If you are uploading results data (i.e. results, indicators and periods for existing activities), you will need to use the XLSX import. If you are uploading basic activity data, which can include budgets and transactions, you can choose between the CSV and XLSX imports.
+
+CSV template
+------------
+IATI Publisher has a single CSV import template, which covers all elements of the IATI Standard for activities apart from `results <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/>`_.
+
+This template is recommended if you:
+
+- want to work in a single flat file, rather than a workbook with multiple sheets
+- don't need embedded codelists or dropdown menus to enter your data
+
+
+XLSX templates
+---------------
+There are four templates available on the `XLSX import page <https://publisher.iatistandard.org/import/xls>`_:
+
+1. Basic Activity Data - covers core and optional IATI data elements for activities, including transactions
+2. Results - to import `results <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/>`_ for existing activities
+3. Indicators - to import `indicators <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/indicator/>`_ for existing results
+4. Periods - to import `periods <https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/indicator/period/>`_ for existing indicators
+
+These templates are recommended if you:
+
+- prefer to work in a workbook that has multiple sheets (typically one per element of the IATI Standard)
+- find embedded codelists and dropdown menus helpful for entering your data
+- need help distinguishing between elements of the IATI Standard that require a single entry (e.g. activity status), versus those that accept multiple entries (e.g. budget)
+
+Only one template can be uploaded at a time. It is normally recommended to `export existing activity data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_ before adding to it via the import functionality.

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -16,7 +16,9 @@ The XLSX templates are split into sheets, which correspond to different data ele
 
 Column colour-coding
 """""""""""""""""""""
-Columns in the XLSX templates are colour-coded pink, green, orange or blue based on the number of row entries expected.
+Columns in the XLSX templates are colour-coded based on the number of row entries expected. 
+
+Note - this only applies if you choose to populate the sheet. `Core elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ are mandatory, whereas other sheets in the template are optional.
 
 - Pink - column expects a single entry
 - Green - column expects at least one entry, and multiple entries are allowed (e.g. for title narratives in multiple languages)

--- a/docs/how-to-xlsx.rst
+++ b/docs/how-to-xlsx.rst
@@ -6,14 +6,6 @@ If you are using IATI Publisher's XLSX templates, we recommend `exporting your e
 
 The XLSX templates are split into sheets, which correspond to different data elements of the IATI Standard.
 
-Tips for using the XLSX templates
----------------------------------
-- Not all sheets need populating - focus on completing `core data elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ first.
-- The 'Settings' sheet is only needed if you want to override your default values saved in IATI Publisher (i.e. for individual activities that you are importing).
-- If you are entering multiple values (e.g. transactions), enter these over multiple rows in the relevant sheet.
-- Don't edit sheet or column names, or change the order of columns in a sheet.
-- Don't make any edits to the 'Options' sheet.
-
 Column colour-coding
 """""""""""""""""""""
 Columns are colour-coded pink, green, orange or blue based on the number of row entries expected.
@@ -23,3 +15,9 @@ Columns are colour-coded pink, green, orange or blue based on the number of row 
 - Orange - column is optional and expects a single entry if you choose to complete it
 - Blue - column is optional and can have multiple entries if you choose to complete it
 
+.. admonition:: Tips
+   - Not all sheets need populating - focus on completing `core data elements <https://docs.publisher.iatistandard.org/en/latest/basic-activity-data/#core-elements>`_ first.
+   - The 'Settings' sheet is only needed if you want to override your default values saved in IATI Publisher (i.e. for individual activities that you are importing).
+   - If you are entering multiple values (e.g. transactions), enter these over multiple rows in the relevant sheet.
+   - Don't edit sheet or column names, or change the order of columns in a sheet.
+   - Don't make any edits to the 'Options' sheet.

--- a/docs/which-template.rst
+++ b/docs/which-template.rst
@@ -30,3 +30,5 @@ These templates are recommended if you:
 - need help distinguishing between elements of the IATI Standard that require a single entry (e.g. activity status), versus those that accept multiple entries (e.g. budget)
 
 Only one template can be uploaded at a time. It is normally recommended to `export existing activity data <https://docs.publisher.iatistandard.org/en/latest/bulk-import/#exporting-your-existing-data>`_ before adding to it via the import functionality.
+
+See `How do I complete the XLSX templates? <https://docs.publisher.iatistandard.org/en/latest/how-to-xlsx/>`_ for more guidance.


### PR DESCRIPTION
Adding a new docs page to describe how to use the XLSX templates. This will replace the instructions in the templates themselves.